### PR TITLE
Adjust regular hour totals to exclude overtime

### DIFF
--- a/payroll.py
+++ b/payroll.py
@@ -309,7 +309,12 @@ def _main(args):
     # Calc Diff
     sheet_hours = sheet.groupby(["Last Name", "First Name"], group_keys=True)[["Regular", "OT"]].sum(numeric_only=True)
     sheet_hours["Total"] = sheet_hours.sum(axis=1, numeric_only=True)
-    d["Total Regular"] = d[["Day", "Paddington Day", "Night", "Paddington Night"]].sum(axis=1, numeric_only=True)
+    # The regular hour total should exclude overtime. Summing the "Day" and "Night"
+    # columns directly was double-counting the OT portions because the grouped
+    # dataframe already has overtime split out into the "Total OT" column.
+    # Instead, derive the regular total by subtracting overtime from the overall
+    # hours to ensure OT is not included twice.
+    d["Total Regular"] = (d["Total Hours"] - d["Total OT"]).round(2)
 
     hours_output["Diff Regular"] = (d["Total Regular"] - sheet_hours["Regular"]).round(2)
     hours_output["Diff OT"]      = (d["Total OT"]      - sheet_hours["OT"]).round(2)

--- a/web/src/hooks/usePayroll.ts
+++ b/web/src/hooks/usePayroll.ts
@@ -270,21 +270,22 @@ export const runPayroll = (
 
 		const payrateSummary = summary_payrate[name];
 
-		const totalreg_hours_raw =
-			payrateSummary.day +
-			payrateSummary.night +
-			payrateSummary.pday +
-			payrateSummary.pnight;
-		const totalot_hours_raw =
-			payrateSummary.dayot +
-			payrateSummary.nightot +
-			payrateSummary.pdayot +
-			payrateSummary.pnightot;
+                const totalot_hours_raw =
+                        payrateSummary.dayot +
+                        payrateSummary.nightot +
+                        payrateSummary.pdayot +
+                        payrateSummary.pnightot;
+                const total_hours_raw =
+                        payrateSummary.day +
+                        payrateSummary.night +
+                        payrateSummary.pday +
+                        payrateSummary.pnight +
+                        totalot_hours_raw;
+                const totalreg_hours_raw = total_hours_raw - totalot_hours_raw;
 
-		const totalreg_hours = _.round(totalreg_hours_raw, 2);
-		const totalot_hours = _.round(totalot_hours_raw, 2);
-		const total_hours_raw = totalreg_hours_raw + totalot_hours_raw;
-		const total_hours = _.round(total_hours_raw, 2);
+                const totalot_hours = _.round(totalot_hours_raw, 2);
+                const total_hours = _.round(total_hours_raw, 2);
+                const totalreg_hours = _.round(totalreg_hours_raw, 2);
 
 		const originalRegularHours = shifts.reduce((a, v) => {
 			if (name.includes("Clara")) {
@@ -304,9 +305,9 @@ export const runPayroll = (
 			0,
 		);
 
-		const diffreg = _.round(totalreg_hours_raw - originalRegularHours, 2);
-		const diffot = _.round(totalot_hours_raw - originalOTHours, 2);
-		const difftotal = _.round(total_hours_raw - originalTotalHours, 2);
+                const diffreg = _.round(totalreg_hours - originalRegularHours, 2);
+                const diffot = _.round(totalot_hours - originalOTHours, 2);
+                const difftotal = _.round(total_hours - originalTotalHours, 2);
 
 		const hoursRow: PayrollRow = {
 			lastName: shifts[0]["Last Name"],


### PR DESCRIPTION
## Summary
- derive total regular hours from the overall total minus overtime to avoid double counting
- base diff calculations on the rounded totals so comparisons stay aligned with the source data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a0114ac8832389c6403eb9e6d215